### PR TITLE
#1: implement basic timezone management

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+timezone_zone: "UTC"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: ensure tzdata is reconfigured
+  command: dpkg-reconfigure --frontend noninteractive tzdata
+  become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- import_tasks: timezone.yml

--- a/tasks/timezone.yml
+++ b/tasks/timezone.yml
@@ -1,0 +1,17 @@
+---
+- name: ensure system-wize timezone is configured
+  block:
+
+  - name: ensure system-wide localtime is configured
+    file:
+      src: /usr/share/zoneinfo/{{ timezone_zone }}
+      dest: /etc/localtime
+      state: link
+      force: true
+
+  - name: ensure system-wide timezone is configured
+    template:
+      src: timezone.j2
+      dest: /etc/timezone
+    notify: ensure tzdata is reconfigured
+  become: true

--- a/templates/timezone.j2
+++ b/templates/timezone.j2
@@ -1,0 +1,1 @@
+{{ timezone_zone }}


### PR DESCRIPTION
 - support debian only
 - configure system-wide localtime and timezone
 - reconfigures tzdata package if there changes in timezone
 - defaults to UTC